### PR TITLE
fix: correct link to Prompt Engineering Patterns Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Here’s a quick reference table of the main techniques covered in this handbook
 ## 🗂️ Prompt Patterns
 **Concept:** Prompt templates that capture best practices.
 
-For a full catalog of reusable prompt engineering patterns, check out the [Prompt Engineering Patterns Handbook](https://github.com/your-username/prompt-engineering-patterns).
+For a full catalog of reusable prompt engineering patterns, check out the [Prompt Engineering Patterns Handbook](https://github.com/trinchetto/prompt-engineering-patterns-handbook).
 
 [🔝 Back to Top](#-techniques-at-a-glance)
 
@@ -212,4 +212,4 @@ This handbook is a working reference. Use it to:
 
 With these techniques, you can confidently build Custom GPTs that are useful, safe, and aligned with your goals. 🚀
 
-- 📘 [Prompt Engineering Patterns Handbook](https://github.com/your-username/prompt-engineering-patterns)
+- 📘 [Prompt Engineering Patterns Handbook](https://github.com/trinchetto/prompt-engineering-patterns-handbook)


### PR DESCRIPTION
## Summary
- fix broken link to the Prompt Engineering Patterns Handbook in README

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e9a4e1a48320a7f270a42e649a02