### PR TITLE
Add Chain-of-Thought prompting technique

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Here’s a quick reference table of the main techniques covered in this handbook
 | [🎛️ CAPITAL Framework](#-the-capital-framework) | Tone/style inconsistency | Adjust conversation style along seven dimensions |
 | [🎭 Building a Persona Pattern](#-building-a-persona-pattern) | Unfocused or inconsistent persona | Define a role + task for consistent behavior |
 | [🗂️ Prompt Patterns](#-prompt-patterns) | Repetitive prompt writing | Use reusable templates and best practices |
+| [🧠 Chain-of-Thought Prompting](#-chain-of-thought-prompting) | Needs deeper reasoning | Encourage step-by-step reasoning before answering |
 | [🧾 Format of the Persona Pattern](#-format-of-the-persona-pattern) | Ambiguous persona prompts | Standardize with “Act as X, Perform Y” format |
 | [🧪 Benchmarking & Testing](#-benchmarking--testing) | Inconsistent performance | Test with benchmark queries and evaluation rubrics |
 | [🔄 Continuous Learning](#-continuous-learning--staying-connected) | Outdated behavior | Update GPTs regularly with new data and practices |
@@ -136,6 +137,21 @@ Here’s a quick reference table of the main techniques covered in this handbook
 **Concept:** Prompt templates that capture best practices.
 
 For a full catalog of reusable prompt engineering patterns, check out the [Prompt Engineering Patterns Handbook](https://github.com/trinchetto/prompt-engineering-patterns-handbook).
+
+[🔝 Back to Top](#-techniques-at-a-glance)
+
+---
+
+## 🧠 Chain-of-Thought Prompting
+**Problem it Solves:** GPTs may jump to conclusions without showing their reasoning.
+
+**How it Works:** Instruct the model to think through problems step by step before giving a final answer.
+
+**When to Use:** Complex questions that benefit from transparent logic — math, planning, debugging, or multi-step analysis.
+
+**Examples:**
+- "Think step-by-step: if a train leaves at 3 PM and travels 60 mph..."
+- "Plan a project timeline. Show your reasoning before the schedule."
 
 [🔝 Back to Top](#-techniques-at-a-glance)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Here’s a quick reference table of the main techniques covered in this handbook
 | [🎭 Building a Persona Pattern](#-building-a-persona-pattern) | Unfocused or inconsistent persona | Define a role + task for consistent behavior |
 | [🗂️ Prompt Patterns](#-prompt-patterns) | Repetitive prompt writing | Use reusable templates and best practices |
 | [🧠 Chain-of-Thought Prompting](#-chain-of-thought-prompting) | Needs deeper reasoning | Encourage step-by-step reasoning before answering |
+| [🔁 ReAct Prompting](#-react-prompting) | Requires reasoning with real-world feedback | Alternate between thinking and acting to gather info |
 | [🧾 Format of the Persona Pattern](#-format-of-the-persona-pattern) | Ambiguous persona prompts | Standardize with “Act as X, Perform Y” format |
 | [🧪 Benchmarking & Testing](#-benchmarking--testing) | Inconsistent performance | Test with benchmark queries and evaluation rubrics |
 | [🔄 Continuous Learning](#-continuous-learning--staying-connected) | Outdated behavior | Update GPTs regularly with new data and practices |
@@ -152,6 +153,21 @@ For a full catalog of reusable prompt engineering patterns, check out the [Promp
 **Examples:**
 - "Think step-by-step: if a train leaves at 3 PM and travels 60 mph..."
 - "Plan a project timeline. Show your reasoning before the schedule."
+
+[🔝 Back to Top](#-techniques-at-a-glance)
+
+---
+
+## 🔁 ReAct Prompting
+**Problem it Solves:** Models can hallucinate or act without verifying facts from the environment.
+
+**How it Works:** The model alternates between "Thought" and "Action" steps, observing results before continuing.
+
+**When to Use:** Tasks requiring tool use or web queries where reasoning must incorporate new information.
+
+**Examples:**
+- "Search the web for the latest GDP figures. Thought: plan the query. Action: call web-search."
+- "Use calculator: Thought: set up equation. Action: invoke calculator to compute."
 
 [🔝 Back to Top](#-techniques-at-a-glance)
 


### PR DESCRIPTION
## Summary
- expand handbook with Chain-of-Thought Prompting pattern for deeper reasoning

## Testing
- `npm test` (fails: Could not read package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a565d951e083208e885904885bd10e